### PR TITLE
Fixup obvious typo in copywrite

### DIFF
--- a/memoryCalabashPlugin/XAMemoryPluginCalabash.m
+++ b/memoryCalabashPlugin/XAMemoryPluginCalabash.m
@@ -1,13 +1,11 @@
 //
-//  SRScreenRecorder.m
-//  ScreenRecorder
+//  XAMemoryPluginCalabash.h
+//  XAMemoryPluginCalabash
 //
-//  Created by kishikawa katsumi on 2012/12/26.
-//  Copyright (c) 2012年 kishikawa katsumi. All rights reserved.
+//  Created by Karl Krukow on 2014/03/11.
+//  Copyright (c) 2014 Xamarin Inc. All rights reserved.
 //
-
 #import "XAMemoryPluginCalabash.h"
-
 
 @implementation XAMemoryPluginCalabash {
 }


### PR DESCRIPTION
I think there is a cut-and-paste error in the copyright notice.

FYI/BTW - I have not been including these notices on new files.  
- I don't think they have any legal meaning.
- They get out of date/sync.
