### PR TITLE
Expose 'load' as public API

### DIFF
--- a/memoryCalabashPlugin/XAMemoryPluginCalabash.h
+++ b/memoryCalabashPlugin/XAMemoryPluginCalabash.h
@@ -12,7 +12,6 @@
 
 @interface XAMemoryPluginCalabash : NSObject
 
-
-+ (XAMemoryPluginCalabash *)sharedInstance;
++ (void)load;
 
 @end

--- a/memoryCalabashPlugin/XAMemoryPluginCalabash.h
+++ b/memoryCalabashPlugin/XAMemoryPluginCalabash.h
@@ -9,7 +9,6 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
-
 @interface XAMemoryPluginCalabash : NSObject
 
 + (void)load;

--- a/memoryCalabashPlugin/XAMemoryPluginCalabash.m
+++ b/memoryCalabashPlugin/XAMemoryPluginCalabash.m
@@ -7,8 +7,8 @@
 //
 #import "XAMemoryPluginCalabash.h"
 
-@implementation XAMemoryPluginCalabash {
-}
+@implementation XAMemoryPluginCalabash
+
 +(void)load {
   [[XAMemoryPluginCalabash sharedInstance] setupNotifications];
 }

--- a/memoryCalabashPlugin/XAMemoryPluginCalabash.m
+++ b/memoryCalabashPlugin/XAMemoryPluginCalabash.m
@@ -5,6 +5,7 @@
 //  Created by Karl Krukow on 2014/03/11.
 //  Copyright (c) 2014 Xamarin Inc. All rights reserved.
 //
+
 #import "XAMemoryPluginCalabash.h"
 
 @implementation XAMemoryPluginCalabash
@@ -15,33 +16,36 @@
 
 + (XAMemoryPluginCalabash *)sharedInstance
 {
-    static XAMemoryPluginCalabash *sharedInstance = nil;
-    static dispatch_once_t pred;
-    dispatch_once(&pred, ^{
-        sharedInstance = [[XAMemoryPluginCalabash alloc] init];
-    });
-    return sharedInstance;
+  static XAMemoryPluginCalabash *sharedInstance = nil;
+  static dispatch_once_t pred;
+  dispatch_once(&pred, ^{
+    sharedInstance = [[XAMemoryPluginCalabash alloc] init];
+  });
+  return sharedInstance;
 }
 
 - (id)init
 {
-    self = [super init];
-    if (self) {
-    }
+  self = [super init];
+  if (self) {
+  }
   NSLog(@"good");
-    return self;
+  return self;
 }
 
 - (void)dealloc
 {
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 - (void)setupNotifications
 {
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationDidReceiveMemoryWarning:) name:UIApplicationDidReceiveMemoryWarningNotification object:nil];
+  [[NSNotificationCenter defaultCenter]
+   addObserver:self
+   selector:@selector(applicationDidReceiveMemoryWarning:)
+   name:UIApplicationDidReceiveMemoryWarningNotification
+   object:nil];
 }
-
 
 - (void)applicationDidReceiveMemoryWarning:(NSNotification *)notification
 {

--- a/memoryCalabashPlugin/XAMemoryPluginCalabash.m
+++ b/memoryCalabashPlugin/XAMemoryPluginCalabash.m
@@ -31,7 +31,6 @@
   self = [super init];
   if (self) {
   }
-  NSLog(@"good");
   return self;
 }
 

--- a/memoryCalabashPlugin/XAMemoryPluginCalabash.m
+++ b/memoryCalabashPlugin/XAMemoryPluginCalabash.m
@@ -11,7 +11,9 @@
 @implementation XAMemoryPluginCalabash
 
 +(void)load {
+  NSLog(@"Calabash Memory Plugin: loading...");
   [[XAMemoryPluginCalabash sharedInstance] setupNotifications];
+  NSLog(@"Calabash Memory Plugin: registered for low-memory warnings");
 }
 
 + (XAMemoryPluginCalabash *)sharedInstance


### PR DESCRIPTION
I am not sure what the public API should be, so I took a guess.

As it was, you could call `[XAMemoryPluginCalabash sharedInstance]`, but you could not call `[XAMemoryPluginCalabash load]`.

The other option would be:

``` objective-c
# .h
@interface XAMemoryPluginCalabash : NSObject

+ (XAMemoryPluginCalabash)sharedInstance;
- (void)load;

@end

# .m
-(void)load {
  [[XAMemoryPluginCalabash sharedInstance] setupNotifications];
}
```
